### PR TITLE
edits on problem sets + ps link fixes

### DIFF
--- a/src/problem_sets/problem_set_1.md
+++ b/src/problem_sets/problem_set_1.md
@@ -11,19 +11,19 @@ kernelspec:
 
 # Problem Set 1
 
-See "Check Your Understanding" from {doc}`basics <../python_fundamentals/basics>` and {doc}`collections <../python_fundamentals/collections>`
+See "Check Your Understanding" from {doc}`Basics <../python_fundamentals/basics>` and {doc}`Collections <../python_fundamentals/collections>`
 
 ## Question 1
 
 Below this cell, add
 
-1. A markdown cell with
+1. A Markdown cell with
    -  two levels of headings;
-   -  a numbered list;
-   -  an unnumbered list;
+   -  a numbered list (We ask for a list in Markdown, not a Python list object);
+   -  an unnumbered list (again not a Python list object);
    -  text with a `%` and a `-` sign (hint: look at this cell and [escape characters](https://www.markdownguide.org/basic-syntax/#characters-you-can-escape))
    -  backticked code (see [https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet))
-1. A markdown cell with
+1. A Markdown cell with
    - the [quadratic formula](https://en.wikipedia.org/wiki/Quadratic_formula) embedded in the cell using [LaTeX](https://jupyter-notebook.readthedocs.io/en/stable/examples/Notebook/Typesetting%20Equations.html)
 
 ## Question 2

--- a/src/problem_sets/problem_set_2.md
+++ b/src/problem_sets/problem_set_2.md
@@ -11,7 +11,7 @@ kernelspec:
 
 # Problem Set 2
 
-See "Check Your Understanding" from {doc}`collections <../python_fundamentals/collections>` and {doc}`control flow <../python_fundamentals/control_flow>`
+See "Check Your Understanding" from {doc}`Collections <../python_fundamentals/collections>` and {doc}`Control Flow <../python_fundamentals/control_flow>`
 
 Note:  unless stated otherwise, the timing of streams of payoffs is immediately at
 time `0` where appropriate.  For example, dividends $\{d_1, d_2, \ldots d_{\infty}\}$

--- a/src/problem_sets/problem_set_3.md
+++ b/src/problem_sets/problem_set_3.md
@@ -11,7 +11,7 @@ kernelspec:
 
 # Problem Set 3
 
-See "Check Your Understanding" from {doc}`../python_fundamentals/control_flow <../python_fundamentals/control_flow>`, {doc}`../python_fundamentals/functions <../python_fundamentals/functions>`, and {doc}`../scientific/numpy_arrays <../scientific/numpy_arrays>`
+See "Check Your Understanding" from {doc}`Control Flow <../python_fundamentals/control_flow>`, {doc}`Functions <../python_fundamentals/functions>`, and {doc}`Introduction to Numpy <../scientific/numpy_arrays>`
 
 ## Question 1
 
@@ -92,7 +92,7 @@ F2(1.0, 0.5)
 
 Now, it is your turn...
 
-Re-write the `returns_to_scale` function above to accept an additional argument
+Re-write the `returns_to_scale` function above as we had in {doc}`Functions <../python_fundamentals/functions>` to accept an additional argument
 `F` that represents a production function. The function should take in `K` and `L`
 and return output.
 
@@ -133,7 +133,7 @@ What are the returns to scale when you set `alpha_1 = 0.3` and `alpha_2 = 0.6`?
 What about when you use `alpha_1 = 0.4` and `alpha_2 = 0.65`?
 
 ```{code-cell} python
-# test with alpha_1 = 0.3 and alpha_2 = 0.65
+# test with alpha_1 = 0.4 and alpha_2 = 0.65
 ```
 
 What do returns to scale have to do with the quantity $\alpha_1 + \alpha_2$? When will returns to scale be greater or less than 1?

--- a/src/problem_sets/problem_set_4.md
+++ b/src/problem_sets/problem_set_4.md
@@ -11,9 +11,9 @@ kernelspec:
 
 # Problem Set 4
 
-See "Check Your Understanding" from {doc}`../scientific/applied_linalg <../scientific/applied_linalg>` and {doc}`../scientific/randomness <../scientific/randomness>`
+See "Check Your Understanding" from {doc}`Applied Linear Algebra <../scientific/applied_linalg>`, {doc}`Randomness <../scientific/randomness>`, and {doc}`Optimization <../scientific/optimization>`
 
-## Question 1 and 2
+## Question 1
 
 Alice is a stock broker who owns two types of assets: A and B. She owns 100
 units of asset A and 50 units of asset B. The current interest rate is 5%.
@@ -21,8 +21,6 @@ Each of the A assets have a remaining duration of 6 years and pay
 $1500$ dollars each year while each of the B assets have a remaining duration
 of 4 years and pay $500$ dollars each year (assume the first payment starts at the beginning of the
 first year and hence, should not be discounted).
-
-### Question 1
 
 Alice would like to retire if she
 can sell her assets for more than $1 million. Use vector addition, scalar
@@ -34,25 +32,9 @@ r = 0.05
 # your code here
 ```
 
-### Question 2
+## Question 2
 
-Consider if Alice had several alternate portfolios and decide which is the most valuable.
-Use a matrix product to simultaneously calculate the values of each portfolio,
-as we did in the lecture notes.
-
-- Portfolio 1: 100 units of A, 40 units of B
-- Portfolio 2: 50 units of A, 150 units of B
-- Portfolio 3: 120 units of A, 0 units of B
-
-```{code-cell} python
-r = 0.05
-
-# your code here
-```
-
-## Question 3
-
-As in {doc}`../scientific/applied_linalg <../scientific/applied_linalg>`:
+As in {doc}`Applied Linear Algebra <../scientific/applied_linalg>`:
 
 Consider an economy where in any given year, $\alpha = 3\%$ of workers lose their jobs and
 $\phi = 12\%$ of unemployed workers find jobs.
@@ -81,6 +63,7 @@ one.
 # your code here
 ```
 
+<!---
 ## Question 4
 
 Adapt our unemployment example to add in an additional category: a probationary period where a firm is deciding if they want to make
@@ -97,26 +80,27 @@ Adapting the code from the lecture notes, plot the mass of all three types of em
 ```{code-cell} python
 # your code here
 ```
+-->
 
-## Question 5
+## Question 3
 
 Wikipedia and other credible statistics sources tell us that the mean and
 variance of the Uniform(0, 1) distribution are (1/2, 1/12) respectively.
 
 How could we check whether the numpy random numbers approximate these
-values? (*hint*: some functions in {doc}`../scientific/numpy_arrays <../scientific/numpy_arrays>` and {doc}`../scientific/randomness <../scientific/randomness>` might be useful)
+values? (*hint*: some functions in {doc}`Introduction to Numpy <../scientific/numpy_arrays>` and {doc}`Randomness <../scientific/randomness>` might be useful)
 
 ```{code-cell} python
 # your code here
 ```
 
-## Question 6
+## Question 4
 
 Assume you have been given the opportunity to choose between one of three financial assets.
 
 You will be given the asset for free, allowed to hold it indefinitely, and will keep all payoffs.
 
-Also assume the assets' payoffs are distributed as follows (the notations are the same as in "Continuous Distributions" subsection of {doc}`../scientific/randomness <../scientific/randomness>`):
+Also assume the assets' payoffs are distributed as follows (the notations are the same as in "Continuous Distributions" subsection of {doc}`Randomness <../scientific/randomness>`):
 
 1. Normal with $\mu = 10, \sigma = 5$
 1. Gamma with $k = 5.3, \theta = 2$
@@ -126,7 +110,7 @@ Use `scipy.stats` to answer the following questions:
 
 - Which asset has the highest average returns?
 - Which asset has the highest median returns?
-- Which asset has the lowest coefficient of variation, i.e., standard deviation divided by mean? (This measure is similar to "Sharpe Ratio")
+- Which asset has the lowest coefficient of variation, i.e., standard deviation divided by mean?
 - Which asset would you choose? Why? (There is not a single right answer here. Just be creative and express your preferences.)
 
 You can find the official documentation of `scipy.stats` [here](https://docs.scipy.org/doc/scipy/reference/stats.html)
@@ -135,9 +119,10 @@ You can find the official documentation of `scipy.stats` [here](https://docs.sci
 # your code here
 ```
 
+<!---
 ## Question 7
 
-Let's revisit the unemployment example from the {doc}`../scientific/applied_linalg <../scientific/applied_linalg>`.
+Let's revisit the unemployment example from the {doc}`Applied Linear Algebra <../scientific/applied_linalg>`.
 
 We'll repeat necessary details here.
 
@@ -199,4 +184,6 @@ With this simulation, plot the average proportion of `M` agents in the employmen
 
 # Long-run average payment
 ```
+-->
 
+<!--- add new Q5, Q6 here -->

--- a/src/problem_sets/problem_set_4.md
+++ b/src/problem_sets/problem_set_4.md
@@ -119,7 +119,72 @@ You can find the official documentation of `scipy.stats` [here](https://docs.sci
 # your code here
 ```
 
+## Question 5
+
+Take the example with preferences over bananas (B) and apples (A) in {doc}`Optimization <../scientific/optimization>`
+
+The consumer solves the following problem:
+
+$$
+\begin{aligned}
+\max_{A, B} & B^{\alpha}A^{1-\alpha}\\
+\text{s.t. } & p_A A + B \leq W
+\end{aligned}
+$$
+
+Fix $p_A = 2$ and $\alpha = 0.33$.  Make a grid of ``W`` between ``1`` and ``3`` and then plot the optimal ratio of B to A.
+
+```{code-cell} python
+p_A = 2
+alpha = 0.33
+
+# Your code here
+```
+
+Do the same graph for $\alpha = 0.5$ and compare/interpret.
+
+```{code-cell} python
+# Your code here
+```
+
 <!---
+.. Next year...
+.. **TODO assignment?** See how the marginal utility changes as you take alpha towards 0 or 1, and explain.  Then look at how the indifference curves change.
+.. **TODO assignment?** Numerically demonstrate the wealth effect and the income effect in a graph using the optimization approach.  Maybe look at another utility function such as log utility?
+-->
+
+## Question 6
+Normalize the price of potato chips to be $1$ and set the price of chocolate bars to be $q$.
+
+Using a similar approach as seen in the apples/bananas example above, solve for the optimal
+basket of potato chips and chocolate bars.
+
+$$
+\begin{aligned}
+\max_{P, C} & -(P - 20)^2 - 2 * (C - 1)^2\\
+\text{s.t. } & P + q C \leq W
+\end{aligned}
+$$
+
+Hint:  When analyzing bliss points, as in {doc}`Optimization ../scientific/optimization`, we need to consider that they may not reach the bliss point.  Remember that in the algebra for our problems, we were only able to substitute using the budget constraint if the budget constraint is binding under optimal consumption bundles.
+
+Fix the price for chocolate bars to be $q = 10$
+
+Find the optimal quantity of $C$ and $P$ for $W = 20$
+
+```{code-cell} python
+W = 20
+q = 10
+
+# Your code here
+```
+
+Now, do the same thing for a grid of $W$ between $20$ and $50$ and plot the optimal $C$ and $P$ in a single graph.
+
+```{code-cell} python
+# Your code here
+```
+
 ## Question 7
 
 Let's revisit the unemployment example from the {doc}`Applied Linear Algebra <../scientific/applied_linalg>`.
@@ -184,6 +249,3 @@ With this simulation, plot the average proportion of `M` agents in the employmen
 
 # Long-run average payment
 ```
--->
-
-<!--- add new Q5, Q6 here -->

--- a/src/problem_sets/problem_set_5.md
+++ b/src/problem_sets/problem_set_5.md
@@ -11,7 +11,7 @@ kernelspec:
 
 # Problem Set 5
 
-See {doc}`../scientific/optimization <../scientific/optimization>`, {doc}`../pandas/intro <../pandas/intro>`, and {doc}`../pandas/basics <../pandas/basics>`
+See {doc}`Optimization <../scientific/optimization>`, {doc}`Introduction <../pandas/intro>`, and {doc}`Basic Functionality <../pandas/basics>`
 
 ```{code-cell} python
 import pandas as pd
@@ -25,7 +25,7 @@ qeds.themes.mpl_style();
 
 ## Setup for Question 1-5
 
-Load data from the {doc}`../pandas/basics <../pandas/basics>` lecture.
+Load data from the {doc}`Basic Functionality <../pandas/basics>` lecture.
 
 ```{code-cell} python
 url = "https://datascience.quantecon.org/assets/data/state_unemployment.csv"

--- a/src/problem_sets/problem_set_6.md
+++ b/src/problem_sets/problem_set_6.md
@@ -11,7 +11,7 @@ kernelspec:
 
 # Problem Set 6
 
-See {doc}`../pandas/merge <../pandas/merge>`, {doc}`../pandas/reshape <../pandas/reshape>`, and {doc}`../pandas/groupby <../pandas/groupby>`
+See {doc}`Merge <../pandas/merge>`, {doc}`Reshape <../pandas/reshape>`, and {doc}`GroupBy <../pandas/groupby>`
 
 ```{code-cell} python
 import matplotlib.pyplot as plt

--- a/src/problem_sets/problem_set_7.md
+++ b/src/problem_sets/problem_set_7.md
@@ -11,7 +11,7 @@ kernelspec:
 
 # Problem Set 7
 
-```{code-cell} python3
+```{code-cell} python
 import matplotlib.colors as mplc
 import matplotlib.patches as patches
 import matplotlib.pyplot as plt
@@ -21,13 +21,13 @@ import qeds
 
 ## Question 1
 
-From {doc}`../applications/visualization_rules <../applications/visualization_rules>`
+From {doc}`Data Visualization: Rules and Guidelines <../applications/visualization_rules>`
 
 Create a bar chart of the below data on Canadian GDP growth.
 Use a non-red color for the years 2000 to 2008, red for
 2009, and the first color again for 2010 to 2018.
 
-```{code-cell} python3
+```{code-cell} python
 ca_gdp = pd.Series(
     [5.2, 1.8, 3.0, 1.9, 3.1, 3.2, 2.8, 2.2, 1.0, -2.8, 3.2, 3.1, 1.7, 2.5, 2.9, 1.0, 1.4, 3.0],
     index=list(range(2000, 2018))
@@ -41,7 +41,7 @@ for side in ["right", "top", "left", "bottom"]:
 
 ## Question 2
 
-From {doc}`../applications/visualization_rules <../applications/visualization_rules>`
+From {doc}`Data Visualization: Rules and Guidelines <../applications/visualization_rules>`
 
 Draft another way to organize time and education by modifying the code below.
 That is, have two subplots (one for each
@@ -50,7 +50,7 @@ education level) and four groups of points (one for each year).
 Why do you think they chose to organize the information the way they
 did rather than this way?
 
-```{code-cell} python3
+```{code-cell} python
 # Read in data
 df = pd.read_csv("https://datascience.quantecon.org/assets/data/density_wage_data.csv")
 df["year"] = df.year.astype(int)  # Convert year to int
@@ -85,7 +85,7 @@ Statistics](https://www.transtats.bts.gov/OT_Delay/OT_DelayCause1.asp)
 that describes the cause for all US domestic flight delays
 in November 2016. We used the same data in the previous problem set.
 
-```{code-cell} python3
+```{code-cell} python
 air_perf = qeds.load("airline_performance_dec16") #[["CRSDepTime", "Carrier", "CarrierDelay", "ArrDelay"]]
 air_perf.info()
 air_perf.head

--- a/src/theme/projects.md
+++ b/src/theme/projects.md
@@ -25,6 +25,9 @@ This course is also taught at [Huazhong University of Science and Technology](ht
 - [Factors affecting bike share in San Francisco](https://nbviewer.jupyter.org/github/patkarns/econ-323-final-project/blob/main/final_draft.ipynb)
   - Napat Karnsakultorn
 
+- [Evolution of NBA Player Salary Determinants](https://nbviewer.jupyter.org/github/silaslm/NBA-Player-Salary-Determinants/blob/main/NBA_Player_Salary_Determinants-2.ipynb)
+  - Silas Lee-McNamee
+
 - [Visualization of Circum-Pacific Belt Earthquakes](https://nbviewer.jupyter.org/github/jessicashi98/ECON323/blob/main/final323.ipynb)
   - Jessica Shi
 


### PR DESCRIPTION
@wupeifan this is intended to replicate the PR from the source repo https://github.com/QuantEcon/lecture-source-ds/pull/321 (and also fixes a couple of links in the problem sets post migration to this repo). Could you please add in the new Q5 and Q6 in PS4? I couldn't find it in the new PS5 to move.