### PR TITLE
basics `code-cell` fix

### DIFF
--- a/src/python_fundamentals/basics.md
+++ b/src/python_fundamentals/basics.md
@@ -961,7 +961,7 @@ y = 1.02
 
 The code below is invalid Python code
 
-```{code-cell} markdown
+```{code-cell} python
 :tags: ["remove-output"]
 x = 'What's wrong with this string'
 ```

--- a/src/python_fundamentals/basics.md
+++ b/src/python_fundamentals/basics.md
@@ -962,7 +962,7 @@ y = 1.02
 The code below is invalid Python code
 
 ```{code-cell} python
-:tags: ["remove-output"]
+:tags: ["remove-output", raises-exception]
 x = 'What's wrong with this string'
 ```
 


### PR DESCRIPTION
not sure why this was `md` to begin with in the source repo. if not this, then we could maybe go with `code-block`.