### PR TITLE
 TEST: private-jupyterlab branch of quantecon-book-theme

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,7 @@ dependencies:
     - scikit-learn >= 0.24.0
     - bokeh
     - sphinxcontrib-bibtex
-    - git+https://github.com/QuantEcon/quantecon-book-theme@jupyterlab
+    - git+https://github.com/QuantEcon/quantecon-book-theme@private-jupyterlab
     - nltk
   - conda:
     - python-graphviz


### PR DESCRIPTION
Testing `private-jupyerlab` branch of qe-book-theme :https://github.com/QuantEcon/quantecon-book-theme/tree/private-jupyterlab

You can test this using: `https://pims.syzygy.ca` for `private`