### PR TITLE
[Github Actions] Maintenance 

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,0 +1,29 @@
+name: Build Cache [using jupyter-book]
+on:
+  push:
+    branches:
+      - main
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Anaconda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          auto-activate-base: true
+          miniconda-version: 'latest'
+          python-version: 3.8
+          environment-file: environment.yml
+          activate-environment: quantecon
+      - name: Build HTML
+        shell: bash -l {0}
+        run: |
+          jb build src --path-output ./
+      - name: Upload "_build" folder (cache)
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-cache
+          path: _build

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -17,7 +17,7 @@ jobs:
           miniconda-version: 'latest'
           python-version: 3.8
           environment-file: environment.yml
-          activate-environment: quantecon
+          activate-environment: lecture-datascience
       - name: Build HTML
         shell: bash -l {0}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Download "build" folder (cache)
         uses: dawidd6/action-download-artifact@v2
         with:
-          workflow: publish.yml
+          workflow: cache.yml
           branch: main
           name: build-cache
           path: _build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,16 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
+      # Build Assets (Download Notebooks and PDF via LaTeX)
+      # - name: Build PDF from LaTeX
+      #   shell: bash -l {0}
+      #   run: |
+      #     jb build src --builder pdflatex --path-output ./ -n --keep-going
+      # - name: Copy LaTeX PDF for GH-PAGES
+      #   shell: bash -l {0}
+      #   run: |
+      #     mkdir -p _build/html/_pdf
+      #     cp -u _build/latex/*.pdf _build/html/_pdf
       - name: Build Download Notebooks (sphinx-tojupyter)
         shell: bash -l {0}
         run: |
@@ -39,6 +49,7 @@ jobs:
         run: |
           mkdir -p _build/html/_notebooks
           rsync -r  _build/jupyter/ _build/html/_notebooks/
+      # Build Website
       - name: Build HTML
         shell: bash -l {0}
         run: |
@@ -48,29 +59,25 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: _build/html/
+          # cname: datascience.quantecon.org
       - name: Upload "_build" folder (cache)
         uses: actions/upload-artifact@v2
         with:
-          name: build-cache
+          name: build-publish
           path: _build
-      - name: Prepare lecture-datascience.notebooks sync
-        shell: bash -l {0}
-        run: |
-          mkdir -p _build/lecture-datascience.notebooks
-          cp -a _build/jupyter/. _build/lecture-datascience.notebooks
-          ls -a _build/lecture-datascience.notebooks
-      - name: Commit latest notebooks to lecture-datascience.notebooks
-        uses: cpina/github-action-push-to-another-repository@main
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
-        with:
-          source-directory: '_build/lecture-datascience.notebooks'
-          destination-github-username: 'QuantEcon'
-          destination-repository-name: 'lecture-datascience.notebooks'
-          user-email: services@quantecon.org
-          target-branch: 'main'
-
-          
-
-          
-          # cname: datascience.quantecon.org
+      # - name: Prepare lecture-datascience.notebooks sync
+      #   shell: bash -l {0}
+      #   run: |
+      #     mkdir -p _build/lecture-datascience.notebooks
+      #     cp -a _build/jupyter/. _build/lecture-datascience.notebooks
+      #     ls -a _build/lecture-datascience.notebooks
+      # - name: Commit latest notebooks to lecture-datascience.notebooks
+      #   uses: cpina/github-action-push-to-another-repository@main
+      #   env:
+      #     API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+      #   with:
+      #     source-directory: '_build/lecture-datascience.notebooks'
+      #     destination-github-username: 'QuantEcon'
+      #     destination-repository-name: 'lecture-datascience.notebooks'
+      #     user-email: services@quantecon.org
+      #     target-branch: 'main'


### PR DESCRIPTION
This PR:

1. switches off notebooks syncing to `lecture-datascience.notebooks` until ready to `publish`
2. adds a `cache` workflow for generating a reference `_build` folder
3. Adds a `cache` fetch from `cache.yml` workflow

Tagged based activation for publishing was added in #83 so should be mentioned in the description