### PR TITLE
[MAINT] Upgrade `quantecon-book-theme` and pin version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,7 @@ dependencies:
     - scikit-learn >= 0.24.0
     - bokeh
     - sphinxcontrib-bibtex
-    - git+https://github.com/QuantEcon/quantecon-book-theme@jupyterlab
+    - quantecon-book-theme==0.2.1
     - nltk
   - conda:
     - python-graphviz

--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,7 @@ dependencies:
     - scikit-learn >= 0.24.0
     - bokeh
     - sphinxcontrib-bibtex
-    - quantecon-book-theme==0.2.1
+    - quantecon-book-theme==0.2.2
     - nltk
   - conda:
     - python-graphviz


### PR DESCRIPTION
This may need to wait until the next `quantecon-book-theme` is release via PyPI