### PR TITLE
MAINT: Migrate to quantecon-book-theme==0.2.2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,7 @@ dependencies:
     - scikit-learn >= 0.24.0
     - bokeh
     - sphinxcontrib-bibtex
-    - git+https://github.com/QuantEcon/quantecon-book-theme@jupyterlab
+    - quantecon-book-theme=0.2.2
     - nltk
   - conda:
     - python-graphviz


### PR DESCRIPTION
This PR updates `quantecon-book-theme` to `0.2.2`. 

This PR will need to be rerun once the latest theme is released via PyPI (cc: @AakashGfude)