### PR TITLE
MAINT: Enable `orphan` metadata for documents not included in `_toc.yml`

### DIFF
--- a/lectures/problem_sets/index.md
+++ b/lectures/problem_sets/index.md
@@ -7,6 +7,7 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+orphan: true
 ---
 
 # Problem Sets

--- a/lectures/problem_sets/problem_set_1.md
+++ b/lectures/problem_sets/problem_set_1.md
@@ -7,6 +7,7 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+orphan: true
 ---
 
 # Problem Set 1

--- a/lectures/problem_sets/problem_set_2.md
+++ b/lectures/problem_sets/problem_set_2.md
@@ -7,6 +7,7 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+orphan: true
 ---
 
 # Problem Set 2

--- a/lectures/problem_sets/problem_set_3.md
+++ b/lectures/problem_sets/problem_set_3.md
@@ -7,6 +7,7 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+orphan: true
 ---
 
 # Problem Set 3

--- a/lectures/problem_sets/problem_set_4.md
+++ b/lectures/problem_sets/problem_set_4.md
@@ -7,6 +7,7 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+orphan: true
 ---
 
 # Problem Set 4

--- a/lectures/problem_sets/problem_set_5.md
+++ b/lectures/problem_sets/problem_set_5.md
@@ -7,6 +7,7 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+orphan: true
 ---
 
 # Problem Set 5

--- a/lectures/problem_sets/problem_set_6.md
+++ b/lectures/problem_sets/problem_set_6.md
@@ -7,6 +7,7 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+orphan: true
 ---
 
 # Problem Set 6

--- a/lectures/problem_sets/problem_set_7.md
+++ b/lectures/problem_sets/problem_set_7.md
@@ -7,6 +7,7 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+orphan: true
 ---
 
 # Problem Set 7

--- a/lectures/problem_sets/problem_set_8.md
+++ b/lectures/problem_sets/problem_set_8.md
@@ -7,6 +7,7 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+orphan: true
 ---
 
 # Problem Set 8

--- a/lectures/theme/contributors.md
+++ b/lectures/theme/contributors.md
@@ -7,6 +7,7 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+orphan: true
 ---
 
 # Contributors:

--- a/lectures/theme/projects.md
+++ b/lectures/theme/projects.md
@@ -7,6 +7,7 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+orphan: true
 ---
 
 # Previous Projects:

--- a/lectures/theme/projects_hust.md
+++ b/lectures/theme/projects_hust.md
@@ -7,6 +7,7 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+orphan: true
 ---
 
 # Previous Projects:


### PR DESCRIPTION
This PR enables `orphan: true` for `problem set` documents

fixes #71 (coupled with `jupyter-book=0.11 release`)