### PR TITLE
REFACTOR: Using mathjaxv2 for plotly

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -31,7 +31,20 @@ sphinx:
       launch_buttons:
         colab_url: https://colab.research.google.com
         binderhub_url: https://mybinder.org
-    mathjax_path: https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-svg.js
+    mathjax_config:
+      TeX:
+        extensions: ["autobold.js"]
+        Macros:
+          "argmax" : "arg\\,max"
+          "argmin" : "arg\\,min"
+          "col"    : "col"
+        tex2jax: 
+          inlineMath: [ ['$','$'], ['\\(','\\)'] ]
+          processEscapes: true
+        SVG:
+          scale: 0.92,
+          useGlobalCache: true
+    mathjax_path: https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-MML-AM_SVG
     tojupyter_static_file_path: ["_static"]
     tojupyter_target_html: true
     tojupyter_urlpath: "https://datascience.quantecon.org/"

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -44,7 +44,7 @@ sphinx:
         SVG:
           scale: 0.92,
           useGlobalCache: true
-    mathjax_path: https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-MML-AM_SVG
+    mathjax_path: https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-MML-AM_CHTML
     tojupyter_static_file_path: ["_static"]
     tojupyter_target_html: true
     tojupyter_urlpath: "https://datascience.quantecon.org/"


### PR DESCRIPTION
Using mathjaxv2 for the proper functioning of plotly graphs as was pointed out in this thread https://github.com/QuantEcon/lecture-datascience.myst/issues/142 .

Have also transferred the configuration here in `_config` instead of in the theme, as `mathjax_config` variable works with mathjaxv2.