### PR TITLE
[deploy] sets up deployment context for custom domain

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -14,7 +14,6 @@ sphinx:
   extra_extensions: [sphinx_multitoc_numbering, sphinx_exercise, sphinx_tojupyter]
   config:
     html_favicon: _static/lectures-favicon.ico
-    # html_theme: quantecon_book_theme
     html_static_path: ['_static']
     html_theme: quantecon_book_theme
     html_theme_options:
@@ -31,6 +30,7 @@ sphinx:
       launch_buttons:
         colab_url: https://colab.research.google.com
         binderhub_url: https://mybinder.org
+      google_analytics_id: UA-54984338-5
       persistent_sidebar: true
     mathjax_config:
       TeX:

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -8,7 +8,7 @@ execute:
   timeout: 1000
 
 html:
-  baseurl: https://quantecon.github.io/lecture-datascience.myst/
+  baseurl: https://datascience.quantecon.org/
 
 sphinx:
   extra_extensions: [sphinx_multitoc_numbering, sphinx_exercise, sphinx_tojupyter]
@@ -48,8 +48,8 @@ sphinx:
     mathjax_path: https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-MML-AM_CHTML
     tojupyter_static_file_path: ["_static"]
     tojupyter_target_html: true
-    tojupyter_urlpath: "https://quantecon.github.io/lecture-datascience.myst/"
-    tojupyter_image_urlpath: "https://quantecon.github.io/lecture-datascience.myst/_static/"
+    tojupyter_urlpath: "https://datascience.quantecon.org/"
+    tojupyter_image_urlpath: "https://datascience.quantecon.org/_static/"
     tojupyter_lang_synonyms: ["ipython", "ipython3", "python"]
     tojupyter_kernels:
       python3:


### PR DESCRIPTION
This PR sets the deployment context to use a custom domain:

https://datascience.quantecon.org/