### PR TITLE
[deploy] set cname record

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: _build/html/
-          # cname: datascience.quantecon.org
+          cname: datascience.quantecon.org
       - name: Upload "_build" folder (cache)
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Set's the `cname` record for `gh-pages` during publish workflows