### PR TITLE
MAINT: Adjust _toc.yml to adopt jb-book format structure

### DIFF
--- a/lectures/_toc.yml
+++ b/lectures/_toc.yml
@@ -2,7 +2,6 @@ format: jb-book
 root: index
 parts:
 - caption: Introduction
-  numbered: true
   chapters:
     - file: introduction/index
     - file: introduction/overview
@@ -11,7 +10,6 @@ parts:
     - file: introduction/local_install
     - file: introduction/troubleshooting
 - caption: Python Fundamentals
-  numbered: true
   chapters:
     - file: python_fundamentals/index
     - file: python_fundamentals/basics
@@ -19,7 +17,6 @@ parts:
     - file: python_fundamentals/control_flow
     - file: python_fundamentals/functions
 - caption: Scientific Computing
-  numbered: true
   chapters:
     - file: scientific/index
     - file: scientific/numpy_arrays
@@ -28,7 +25,6 @@ parts:
     - file: scientific/randomness
     - file: scientific/optimization
 - caption: Pandas
-  numbered: true
   chapters:
     - file: pandas/index
     - file: pandas/intro
@@ -42,7 +38,6 @@ parts:
     - file: pandas/timeseries
     - file: pandas/matplotlib
 - caption: Applications
-  numbered: true
   chapters:
     - file: applications/index
     - file: applications/visualization_rules


### PR DESCRIPTION
This PR adjust `_toc.yml` to adopt the `jb-book` format