### PR TITLE
MAINT: upgrade anaconda and ga workflow versions

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Anaconda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           auto-activate-base: true
           miniconda-version: 'latest'
-          python-version: 3.9
+          python-version: 3.11
           environment-file: environment.yml
           activate-environment: lecture-datascience
       - name: Build HTML
@@ -26,7 +26,7 @@ jobs:
         run: |
           jb build lectures --path-output ./
       - name: Upload "_build" folder (cache)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: build-cache
           path: _build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,14 +5,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Anaconda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           auto-activate-base: true
           miniconda-version: 'latest'
-          python-version: 3.9
+          python-version: 3.11
           environment-file: environment.yml
           activate-environment: lecture-datascience
       - name: Display Conda Environment Versions
@@ -22,7 +22,7 @@ jobs:
         shell: bash -l {0}
         run: pip list
       - name: Download "build" folder (cache)
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v3
         with:
           workflow: cache.yml
           branch: main
@@ -33,7 +33,7 @@ jobs:
         run: |
           jb build lectures --path-output ./ -W --keep-going
       - name: Upload Execution Reports
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: execution-reports
@@ -50,7 +50,7 @@ jobs:
           mkdir -p _build/html/assets/data
           cp -a lectures/_data/. _build/html/assets/data/
       - name: Preview Deploy to Netlify
-        uses: nwtgck/actions-netlify@v1.1
+        uses: nwtgck/actions-netlify@v2
         with:
           publish-dir: '_build/html/'
           production-branch: master

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Anaconda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           auto-activate-base: true
           miniconda-version: 'latest'
-          python-version: 3.9
+          python-version: 3.11
           environment-file: environment.yml
           activate-environment: lecture-datascience
       - name: Display Conda Environment Versions
@@ -40,7 +40,7 @@ jobs:
         run: |
           jb build lectures --path-output ./ --builder=custom --custom-builder=jupyter
           zip -r download-notebooks.zip _build/jupyter
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: download-notebooks
           path: download-notebooks.zip
@@ -60,7 +60,7 @@ jobs:
         run: |
           jb build lectures --path-output ./ -W --keep-going
       - name: Upload Execution Reports
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: execution-reports
@@ -72,7 +72,7 @@ jobs:
           publish_dir: _build/html/
           cname: datascience.quantecon.org
       - name: Upload "_build" folder (cache)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: build-publish
           path: _build

--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
     - arviz==0.13.0
     # Datascience Requirements
     - joblib == 1.2.0
-    - interpolation == 2.2.4
+    - interpolation == 2.2.6
     - networkx == 3.0
     - fiona == 1.9.2
     - geopandas == 0.12.2

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - default
 dependencies:
   - python=3.9
-  - anaconda=2022.10
+  - anaconda=2024.02
   - pip
   - pip:
     # Build Requirements


### PR DESCRIPTION
This PR

- [x] upgrades to `anaconda=2024.02`
- [x] upgrades GitHub action workflow versions to latest