### PR TITLE
Scikit-learn parameter renaming

### DIFF
--- a/lectures/applications/recidivism.md
+++ b/lectures/applications/recidivism.md
@@ -331,7 +331,7 @@ sex_encoded = np.array([
 Using `sklearn` it would be:
 
 ```{code-cell} python
-ohe = preprocessing.OneHotEncoder(sparse=False)
+ohe = preprocessing.OneHotEncoder(sparse_output=False)
 sex_ohe = ohe.fit_transform(sex)
 
 # This should shows 0s!
@@ -351,7 +351,7 @@ Finally, we split the data into training and validation (test) subsets.
 ```{code-cell} python
 def prep_data(df, continuous_variables, categories, y_var, test_size=0.15):
 
-    ohe = preprocessing.OneHotEncoder(sparse=False)
+    ohe = preprocessing.OneHotEncoder(sparse_output=False)
 
     y = df[y_var].values
     X = np.zeros((y.size, 0))


### PR DESCRIPTION
In `OneHotEncoder.`, `sparse` was changed to `sparse_output` in v1.2.0 (current version is v1.5.0), see https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.OneHotEncoder.html