### PR TITLE
FIX: migrate build environment to binder

### DIFF
--- a/_notebook_repo/environment.yml
+++ b/_notebook_repo/environment.yml
@@ -2,35 +2,51 @@ name: lecture-datascience
 channels:
   - default
 dependencies:
-  - python=3.9
-  - anaconda=2022.05
+  - python=3.12
+  - anaconda=2024.06
   - pip
   - pip:
-    - joblib
+    # Build Requirements
+    - jupyter-book==0.15.1
+    - docutils==0.17.1
+    - quantecon-book-theme==0.4.1
+    - pydata-sphinx-theme==0.13.1
+    - sphinx-tojupyter==0.3.0
+    - sphinxext-rediraffe==0.2.7
+    - sphinx-exercise==0.4.1
+    - ghp-import==1.1.0
+    - sphinxcontrib-youtube==1.1.0
+    - sphinx-togglebutton==0.3.1
+    - arviz==0.13.0
+    # Datascience Requirements
+    # - joblib
     - interpolation
+    - networkx
     - fiona
     - geopandas
-    - pyLDAvis >= 3.3.0
+    - pyLDAvis
     - gensim
     - folium
     - descartes
-    - pyarrow
+    # - pyarrow
     - xgboost
     - graphviz
-    - networkx
-    - scikit-learn >= 1.0
     - bokeh
     - nltk
-    - beautifulsoup4
+    - pandas-datareader
     - seaborn
     - patsy
-    - quandl
+    - pyarrow
     - statsmodels
     - quantecon
+    - quandl
     - openpyxl
-    - pandas-datareader
     - plotly
     - lxml
+    - scikit-learn
+    # - numba
+    - ipywidgets
+    # - scipy
     - nasdaq-data-link
   - conda:
     - python-graphviz


### PR DESCRIPTION
@doctor-phil not sure if you want to maintain another `environment` but the one in `_notebooks_repo` is old so the binder environment is not buildable at the moment. 

I think that is causing the failures. 

I have copied the base `environment.yml` file over.

Addresses #266 

**Next Steps:**

- [ ] copy this manually to the notebooks repo as a test (**31Jan2025** still failing with the updated environment)
- [ ] this will need a `publish` to run so that contents of `_notebooks_repo` is copied over the repo hosting the notebooks